### PR TITLE
Implement i18n (en, es, ca) support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,13 @@
       "dependencies": {
         "clsx": "^2.1.1",
         "framer-motion": "^12.35.0",
+        "i18next": "^25.8.20",
+        "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.577.0",
         "prettier": "^3.8.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-i18next": "^16.5.8",
         "socket.io-client": "^4.8.3",
         "tailwind-merge": "^3.5.0",
         "zustand": "^5.0.11"
@@ -306,7 +309,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3438,6 +3440,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3464,6 +3475,46 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.8.20",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.20.tgz",
+      "integrity": "sha512-xjo9+lbX/P1tQt3xpO2rfJiBppNfUnNIPKgCvNsTKsvTOCro1Qr/geXVg1N47j5ScOSaXAPq8ET93raK3Rr06A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -4367,6 +4418,33 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.5.8",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.8.tgz",
+      "integrity": "sha512-2ABeHHlakxVY+LSirD+OiERxFL6+zip0PaHo979bgwzeHg27Sqc82xxXWIrSFmfWX0ZkrvXMHwhsi/NGUf5VQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.6.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -4819,7 +4897,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4899,6 +4977,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {
@@ -5070,6 +5157,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,13 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "framer-motion": "^12.35.0",
+    "i18next": "^25.8.20",
+    "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.577.0",
     "prettier": "^3.8.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-i18next": "^16.5.8",
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.11"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,11 @@ import { RoleReveal } from "./components/RoleReveal";
 import { Canvas } from "./components/Canvas";
 import { VotingScreen } from "./components/VotingScreen";
 import { GameResult } from "./components/GameResult";
+import { useTranslation } from "react-i18next";
 
 // App orchestrates the current phase of the game
 function App() {
+  const { t } = useTranslation();
   const phase = useGameStore((state) => state.phase);
   const roomId = useGameStore((state) => state.roomId);
   const myName = useGameStore((state) => state.myName);
@@ -32,7 +34,7 @@ function App() {
     default:
       return (
         <div className="min-h-screen flex items-center justify-center bg-stone-900 text-stone-400">
-          Unknown Game Phase: {phase}
+          {t("common.unknown_phase", { phase })}
         </div>
       );
   }

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import { useGameStore } from "../store/gameState";
 import { Undo, CheckSquare, Clock } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 export const Canvas: React.FC = () => {
+  const { t } = useTranslation();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDrawing, setIsDrawing] = useState(false);
@@ -234,10 +236,10 @@ export const Canvas: React.FC = () => {
             </div>
             <div>
               <p className="text-sm font-bold text-stone-400 uppercase tracking-widest">
-                {isMyTurn ? "Your turn!" : "Now Drawing"}
+                {isMyTurn ? t("canvas.your_turn") : t("canvas.now_drawing")}
               </p>
               <h2 className="text-lg font-bold text-white">
-                {activePlayer?.name || "Someone"}
+                {activePlayer?.name || t("canvas.someone")}
               </h2>
             </div>
           </div>
@@ -247,7 +249,7 @@ export const Canvas: React.FC = () => {
               className={`flex flex-col items-end ${isMyTurn ? "hidden sm:flex" : "block sm:flex"}`}
             >
               <p className="text-xs text-stone-400 font-semibold uppercase mb-1 flex items-center gap-1">
-                <Clock className="w-3 h-3" /> Time
+                <Clock className="w-3 h-3" /> {t("canvas.time")}
               </p>
               <div className="text-2xl font-black text-white px-3 py-1 bg-stone-900 rounded-lg">
                 {(timeLeft / 1000).toFixed(1)}s
@@ -260,7 +262,7 @@ export const Canvas: React.FC = () => {
                 className="bg-ink-secondary hover:bg-white text-black px-5 py-3 rounded-xl font-bold transition-all active:scale-95 shadow-lg shadow-ink-secondary/20 cursor-pointer flex items-center gap-2"
               >
                 <CheckSquare className="w-5 h-5" />
-                <span>Done</span>
+                <span>{t("canvas.done")}</span>
               </button>
             )}
           </div>
@@ -315,8 +317,8 @@ export const Canvas: React.FC = () => {
               <button
                 onClick={undoLastStroke}
                 className="w-10 h-10 rounded-xl bg-stone-700 flex items-center justify-center text-stone-300 hover:bg-stone-600 transition-colors active:scale-95"
-                title="Undo Last Stroke"
-                aria-label="Undo last stroke"
+                title={t("canvas.undo")}
+                aria-label={t("canvas.undo")}
               >
                 <Undo className="w-5 h-5" />
               </button>
@@ -326,7 +328,7 @@ export const Canvas: React.FC = () => {
             <div className="space-y-1">
               <div className="flex justify-between text-xs font-bold uppercase tracking-widest px-1">
                 <span className={OutOfInk ? "text-red-400" : "text-stone-400"}>
-                  Ink Supply
+                  {t("canvas.ink_supply")}
                 </span>
                 <span
                   className={
@@ -334,7 +336,7 @@ export const Canvas: React.FC = () => {
                   }
                 >
                   {OutOfInk
-                    ? "OUT OF INK!"
+                    ? t("canvas.out_of_ink")
                     : `${Math.floor(100 - inkPercentage)}%`}
                 </span>
               </div>

--- a/src/components/GameResult.tsx
+++ b/src/components/GameResult.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import { useGameStore } from "../store/gameState";
 import { CircleQuestionMark, Play } from "lucide-react";
 import { MIN_PLAYERS } from "../lib/constants";
+import { useTranslation, Trans } from "react-i18next";
 
 export const GameResult: React.FC = () => {
+  const { t } = useTranslation();
   const impostorId = useGameStore((state) => state.impostorId);
   const players = useGameStore((state) => state.players);
   const secretWord = useGameStore((state) => state.secretWord);
@@ -55,23 +57,24 @@ export const GameResult: React.FC = () => {
           <h1 className="text-4xl md:text-5xl text-white uppercase tracking-tight mb-8 font-rubik-wet-paint font-extralight">
             {isGameOver
               ? impostorCaught
-                ? "Inkpostor Defeated"
-                : "Inkpostor Won"
-              : "Result of the vote"}
+                ? t("result.defeated")
+                : t("result.won")
+              : t("result.vote_result")}
           </h1>
 
           <div className="text-xl md:text-2xl text-stone-300 font-medium space-y-2">
             {!ejectedId ? (
-              <p className="text-stone-400 italic">Nobody was ejected...</p>
+              <p className="text-stone-400 italic">{t("result.nobody_ejected")}</p>
             ) : (
               <>
                 <p>
-                  <span className="font-bold text-white">{ejectedName}</span>{" "}
-                  was ejected.
+                  <Trans i18nKey="result.ejected_was" values={{ name: ejectedName }}>
+                    <span className="font-bold text-white">{ejectedName}</span> was ejected.
+                  </Trans>
                 </p>
                 {!isGameOver && (
                   <p className="text-stone-400 italic">
-                    Inkpostor is still among us...
+                    {t("result.still_among_us")}
                   </p>
                 )}
               </>
@@ -79,8 +82,9 @@ export const GameResult: React.FC = () => {
 
             {isGameOver && (
               <p className="">
-                <span className="font-bold text-white">{impostorName}</span> was
-                the Inkpostor!
+                <Trans i18nKey="result.impostor_was" values={{ name: impostorName }}>
+                  <span className="font-bold text-white">{impostorName}</span> was the Inkpostor!
+                </Trans>
               </p>
             )}
           </div>
@@ -89,7 +93,7 @@ export const GameResult: React.FC = () => {
         {isGameOver && (
           <div className="bg-stone-800 rounded-2xl p-6 border border-stone-700 shadow-xl animate-in fade-in zoom-in duration-300">
             <p className="text-stone-400 mb-2 uppercase tracking-wider text-sm font-semibold">
-              The secret word was
+              {t("result.secret_word")}
             </p>
             <div className="text-3xl font-black text-white">{secretWord}</div>
           </div>
@@ -109,13 +113,13 @@ export const GameResult: React.FC = () => {
             >
               {isGameOver ? (
                 <span className="text-xl sm:text-2xl tracking-wide uppercase font-rubik-wet-paint font-extralight">
-                  Play Again
+                  {t("result.play_again")}
                 </span>
               ) : (
                 <>
                   <Play className="fill-current w-5 h-5" />
                   <span className="sm:text-xl text-lg font-extrabold uppercase">
-                    Next Round
+                    {t("result.next_round")}
                   </span>
                 </>
               )}
@@ -123,7 +127,7 @@ export const GameResult: React.FC = () => {
           </button>
         ) : (
           <div className="text-stone-500 animate-pulse mt-8">
-            Waiting for host to {isGameOver ? "restart" : "continue"}...
+            {isGameOver ? t("result.waiting_host_restart") : t("result.waiting_host_continue")}
           </div>
         )}
       </div>

--- a/src/components/JoinScreen.tsx
+++ b/src/components/JoinScreen.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
 import { useGameStore } from "../store/gameState";
-import { Users } from "lucide-react";
+import { Users, Globe } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 export const JoinScreen: React.FC = () => {
+  const { t, i18n } = useTranslation();
   const [playerName, setPlayerName] = useState("");
   const [roomId, setRoomId] = useState("");
   const actions = useGameStore((state) => state.actions);
@@ -21,8 +23,25 @@ export const JoinScreen: React.FC = () => {
     actions.connectAndJoin(roomId.toUpperCase(), playerName);
   };
 
+  const changeLanguage = (lng: string) => {
+    i18n.changeLanguage(lng);
+  };
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-4 bg-stone-900">
+      <div className="absolute top-4 right-4 flex gap-2">
+        <Globe className="text-stone-500 w-5 h-5" />
+        <select
+          onChange={(e) => changeLanguage(e.target.value)}
+          value={i18n.language}
+          className="bg-stone-800 text-stone-300 text-xs rounded border border-stone-700 outline-none"
+        >
+          <option value="en">English</option>
+          <option value="es">Español</option>
+          <option value="ca">Català</option>
+        </select>
+      </div>
+
       <div className="max-w-md w-full text-center space-y-8">
         <div className="inline-flex items-center justify-center">
           <img
@@ -42,11 +61,11 @@ export const JoinScreen: React.FC = () => {
           <div className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-stone-400 mb-1 text-left">
-                Your Name
+                {t("join.your_name")}
               </label>
               <input
                 type="text"
-                placeholder="Enter your name"
+                placeholder={t("join.enter_name")}
                 className="w-full px-4 py-3 bg-stone-900 border border-stone-700 rounded-xl focus:ring-2 focus:ring-ink-primary focus:border-transparent transition-all outline-none text-white placeholder-stone-500"
                 value={playerName}
                 onChange={(e) => setPlayerName(e.target.value)}
@@ -61,7 +80,7 @@ export const JoinScreen: React.FC = () => {
                 className="w-full relative group overflow-hidden rounded-xl bg-ink-primary px-4 py-3 font-semibold text-white transition-all hover:bg-ink-primary-accent active:scale-95 disabled:opacity-50 disabled:active:scale-100 flex items-center justify-center gap-2 cursor-pointer"
               >
                 <Users className="w-5 h-5" />
-                <span>Create New Game</span>
+                <span>{t("join.create_game")}</span>
               </button>
             </div>
           </div>
@@ -71,18 +90,20 @@ export const JoinScreen: React.FC = () => {
               <div className="w-full border-t border-stone-700"></div>
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-stone-800 text-stone-500">OR</span>
+              <span className="px-2 bg-stone-800 text-stone-500">
+                {t("join.or")}
+              </span>
             </div>
           </div>
 
           <form onSubmit={handleJoin} className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-stone-400 mb-1 text-left">
-                Room Code
+                {t("join.room_code")}
               </label>
               <input
                 type="text"
-                placeholder="E.g. X7K9A2"
+                placeholder={t("join.eg_room")}
                 className="w-full px-4 py-3 bg-stone-900 border border-stone-700 rounded-xl focus:ring-2 focus:ring-ink-secondary focus:border-transparent transition-all outline-none text-center uppercase tracking-widest text-white placeholder-stone-600"
                 value={roomId}
                 onChange={(e) => setRoomId(e.target.value)}
@@ -94,7 +115,7 @@ export const JoinScreen: React.FC = () => {
               disabled={!playerName || !roomId}
               className="w-full rounded-xl bg-ink-secondary px-4 py-3 font-semibold text-black transition-all hover:bg-white active:scale-95 disabled:opacity-50 disabled:active:scale-100 cursor-pointer"
             >
-              Join Game
+              {t("join.join_game")}
             </button>
           </form>
         </div>

--- a/src/components/Lobby.tsx
+++ b/src/components/Lobby.tsx
@@ -3,8 +3,10 @@ import { useGameStore } from "../store/gameState";
 import { Users, Crown, Loader2, Copy, Check, HelpCircle } from "lucide-react";
 import { MAX_PLAYERS, MIN_PLAYERS } from "../lib/constants";
 import { RulesModal } from "./RulesModal";
+import { useTranslation } from "react-i18next";
 
 export const Lobby: React.FC = () => {
+  const { t } = useTranslation();
   const roomId = useGameStore((state) => state.roomId);
   const players = useGameStore((state) => state.players);
   const myId = useGameStore((state) => state.myId);
@@ -33,7 +35,7 @@ export const Lobby: React.FC = () => {
       <div className="max-w-lg w-full space-y-4 sm:space-y-8">
         <div className="text-center space-y-2 sm:space-y-4">
           <h2 className="text-stone-400 font-medium tracking-widest uppercase text-sm">
-            Room Code
+            {t("lobby.room_code")}
           </h2>
           <button
             type="button"
@@ -44,7 +46,7 @@ export const Lobby: React.FC = () => {
                 ? "hover:border-stone-600 hover:scale-[1.02] active:scale-[0.98] cursor-pointer"
                 : "cursor-not-allowed opacity-60"
             }`}
-            title={hasRoomId ? "Click to copy" : "Room code not ready"}
+            title={hasRoomId ? t("lobby.click_to_copy") : t("lobby.waiting_room_code")}
           >
             <span className="text-5xl font-mono font-bold tracking-[0.2em] text-white">
               {roomId ?? "------"}
@@ -53,7 +55,7 @@ export const Lobby: React.FC = () => {
               {copied ? (
                 <>
                   <Check className="w-3 h-3 text-green-400" />
-                  <span className="text-green-400">Copied!</span>
+                  <span className="text-green-400">{t("lobby.copied")}</span>
                 </>
               ) : (
                 <>
@@ -71,14 +73,14 @@ export const Lobby: React.FC = () => {
                         : "text-stone-600"
                     }
                   >
-                    {hasRoomId ? "Click to copy" : "Waiting for room code..."}
+                    {hasRoomId ? t("lobby.click_to_copy") : t("lobby.waiting_room_code")}
                   </span>
                 </>
               )}
             </div>
           </button>
           <p className="text-stone-500 text-sm">
-            Share this code with your friends to let them join!
+            {t("lobby.share_code")}
           </p>
         </div>
 
@@ -86,7 +88,7 @@ export const Lobby: React.FC = () => {
           <div className="flex items-center justify-between mb-6">
             <h3 className="text-lg sm:text-xl font-bold text-white flex items-center gap-2">
               <Users className="text-ink-secondary w-5 h-5 sm:w-6 sm:h-6" />
-              Players
+              {t("lobby.players")}
             </h3>
             <div className="flex items-center gap-2">
               <button
@@ -99,10 +101,10 @@ export const Lobby: React.FC = () => {
               <span className="bg-stone-700 text-stone-300 text-xs sm:text-sm font-semibold px-3 py-1 rounded-full">
                 {players.length < MAX_PLAYERS ? (
                   <span>
-                    {players.length} / {MAX_PLAYERS} joined
+                    {t("lobby.joined", { count: players.length, max: MAX_PLAYERS })}
                   </span>
                 ) : (
-                  <span className="text-green-400">Full lobby</span>
+                  <span className="text-green-400">{t("lobby.full")}</span>
                 )}
               </span>
             </div>
@@ -131,7 +133,7 @@ export const Lobby: React.FC = () => {
                   <div className="flex items-center text-amber-500 gap-1 bg-amber-500/10 px-2 py-1 rounded border border-amber-500/20">
                     <Crown className="w-4 h-4" />
                     <span className="text-xs font-bold uppercase tracking-wider">
-                      Host
+                      {t("lobby.host")}
                     </span>
                   </div>
                 )}
@@ -141,9 +143,9 @@ export const Lobby: React.FC = () => {
             {players.length < MIN_PLAYERS && (
               <div className="p-4 rounded-xl border border-dashed border-stone-600 bg-stone-800/50 text-center flex flex-col items-center gap-2">
                 <Loader2 className="w-6 h-6 text-stone-500 animate-spin" />
-                <p className="text-stone-400">Waiting for more players...</p>
+                <p className="text-stone-400">{t("lobby.waiting_players")}</p>
                 <p className="text-xs text-stone-500">
-                  Need at least {MIN_PLAYERS} players to start
+                  {t("lobby.need_min", { count: MIN_PLAYERS })}
                 </p>
               </div>
             )}
@@ -157,14 +159,14 @@ export const Lobby: React.FC = () => {
             >
               <div className="flex h-full w-full items-center justify-center gap-2 rounded-2xl px-8 py-3 font-bold text-white transition-all group-hover:bg-opacity-0">
                 <span className="text-xl sm:text-2xl tracking-wide font-rubik-wet-paint font-extralight">
-                  START GAME
+                  {t("lobby.start_game")}
                 </span>
               </div>
             </button>
           ) : (
             <div className="text-center p-4 bg-stone-900 rounded-xl border border-stone-700 animate-pulse">
               <span className="text-stone-400 font-medium">
-                Waiting for host to start...
+                {t("lobby.waiting_host")}
               </span>
             </div>
           )}

--- a/src/components/RoleReveal.tsx
+++ b/src/components/RoleReveal.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
 import { useGameStore } from "../store/gameState";
 import { Brush, Eye } from "lucide-react";
+import { useTranslation, Trans } from "react-i18next";
 
 export const RoleReveal: React.FC = () => {
+  const { t } = useTranslation();
   const [revealed, setRevealed] = useState(false);
   const amIImpostor = useGameStore((state) => state.amIImpostor);
   const secretCategory = useGameStore((state) => state.secretCategory);
@@ -22,9 +24,9 @@ export const RoleReveal: React.FC = () => {
 
       <div className="z-10 max-w-md w-full text-center space-y-8">
         <div className="space-y-2">
-          <h2 className="text-xl font-medium text-stone-400">Phase 1</h2>
+          <h2 className="text-xl font-medium text-stone-400">{t("role.phase")}</h2>
           <h1 className="text-4xl font-black text-white tracking-tight">
-            Your Secret Role
+            {t("role.title")}
           </h1>
         </div>
 
@@ -54,11 +56,13 @@ export const RoleReveal: React.FC = () => {
                       className="h-20"
                     />
                     <h3 className="text-3xl font-black text-white tracking-widest uppercase">
-                      You are the <br />
-                      <span className="text-red-500">Inkpostor</span>
+                      <Trans i18nKey="role.impostor">
+                        You are the <br />
+                        <span className="text-red-500">Inkpostor</span>
+                      </Trans>
                     </h3>
                     <p className="text-red-500 font-medium px-4 py-1 bg-red-900/50 rounded-full border border-red-500/30 text-sm ">
-                      Hint: {secretCategory}
+                      {t("role.hint", { category: secretCategory })}
                     </p>
                   </>
                 ) : (
@@ -69,13 +73,13 @@ export const RoleReveal: React.FC = () => {
                       className="h-20"
                     />
                     <p className="text-emerald-200/80 font-medium mb-0 uppercase tracking-widest text-sm">
-                      The word is
+                      {t("role.word_is")}
                     </p>
                     <h3 className="text-4xl font-black text-white">
                       {secretWord}
                     </h3>
                     <p className="text-emerald-400  font-medium px-4 py-1 bg-emerald-900/50 rounded-full border border-emerald-500/30 text-sm">
-                      Category: {secretCategory}
+                      {t("role.category", { category: secretCategory })}
                     </p>
                   </>
                 )}
@@ -84,7 +88,7 @@ export const RoleReveal: React.FC = () => {
               <div className="flex flex-col items-center text-stone-400 gap-4 transition-transform group-hover:scale-105">
                 <Eye className="w-12 h-12" />
                 <span className="text-lg font-medium">
-                  Press and hold to reveal
+                  {t("role.press_hold")}
                 </span>
               </div>
             )}
@@ -94,14 +98,14 @@ export const RoleReveal: React.FC = () => {
         {isHost ? (
           <div className="pt-8">
             <p className="text-stone-500 text-sm mb-4">
-              Make sure everyone knows their role before continuing.
+              {t("role.make_sure")}
             </p>
             <button
               onClick={actions.proceedToDrawing}
               className="flex items-center justify-center gap-2 w-full rounded-2xl bg-ink-secondary text-stone-900 px-8 py-3 font-bold text-lg transition-all hover:bg-white cursor-pointer active:scale-95 shadow-lg shadow-white/10"
             >
               <Brush className="w-5 h-5" />
-              Start Drawing
+              {t("role.start_drawing")}
             </button>
           </div>
         ) : (
@@ -110,7 +114,7 @@ export const RoleReveal: React.FC = () => {
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-stone-400 opacity-75"></span>
               <span className="relative inline-flex rounded-full h-3 w-3 bg-stone-500"></span>
             </span>
-            Waiting for Host to begin...
+            {t("role.waiting_host")}
           </div>
         )}
       </div>

--- a/src/components/RulesModal.tsx
+++ b/src/components/RulesModal.tsx
@@ -10,6 +10,7 @@ import {
   Trophy,
   Lightbulb,
 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 interface RulesModalProps {
   isOpen: boolean;
@@ -17,6 +18,7 @@ interface RulesModalProps {
 }
 
 export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
+  const { t } = useTranslation();
   const modalRef = useRef<HTMLDivElement>(null);
   const previousFocus = useRef<HTMLElement | null>(null);
 
@@ -70,7 +72,7 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
               id="rules-title"
               className="text-2xl font-extralight text-white font-rubik-wet-paint tracking-wide"
             >
-              How to Play Inkpostor
+              {t("rules.title")}
             </h2>
           </div>
           <button
@@ -89,11 +91,11 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-ink-primary">
               <Target className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                Objective
+                {t("rules.objective.title")}
               </h3>
             </div>
             <p className="text-stone-300 leading-relaxed">
-              Find out who the impostor is… or fool everyone if it's you.
+              {t("rules.objective.description")}
             </p>
           </section>
 
@@ -102,21 +104,21 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-amber-500">
               <Settings className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                Setup
+                {t("rules.setup.title")}
               </h3>
             </div>
             <ul className="space-y-2 text-stone-400 text-sm">
               <li className="flex gap-3">
                 <span className="text-amber-500">•</span>
-                Each player receives a secret word.
+                {t("rules.setup.item1")}
               </li>
               <li className="flex gap-3">
                 <span className="text-amber-500">•</span>
-                All players get the same word, except the impostor.
+                {t("rules.setup.item2")}
               </li>
               <li className="flex gap-3">
                 <span className="text-amber-500">•</span>
-                The impostor receives only a related hint, not the exact word.
+                {t("rules.setup.item3")}
               </li>
             </ul>
           </section>
@@ -126,21 +128,21 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-blue-500">
               <PenTool className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                Drawing Turns
+                {t("rules.drawing.title")}
               </h3>
             </div>
             <ul className="space-y-2 text-stone-400 text-sm">
               <li className="flex gap-3">
                 <span className="text-blue-500">•</span>
-                The game is played in turns.
+                {t("rules.drawing.item1")}
               </li>
               <li className="flex gap-3">
                 <span className="text-blue-500">•</span>
-                In each turn, each player draws a part of the word.
+                {t("rules.drawing.item2")}
               </li>
               <li className="flex gap-3">
                 <span className="text-blue-500">•</span>
-                The drawing is shared: everyone contributes to the same canvas.
+                {t("rules.drawing.item3")}
               </li>
             </ul>
           </section>
@@ -150,17 +152,17 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-purple-500">
               <Search className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                Observe & Deduce
+                {t("rules.observe.title")}
               </h3>
             </div>
             <ul className="space-y-2 text-stone-400 text-sm">
               <li className="flex gap-3">
                 <span className="text-purple-500">•</span>
-                While drawing, try to figure out who doesn't know the word.
+                {t("rules.observe.item1")}
               </li>
               <li className="flex gap-3">
                 <span className="text-purple-500">•</span>
-                The impostor must draw carefully to avoid suspicion.
+                {t("rules.observe.item2")}
               </li>
             </ul>
           </section>
@@ -170,20 +172,20 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-orange-500">
               <Vote className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                Voting Phase
+                {t("rules.voting.title")}
               </h3>
             </div>
             <p className="text-stone-300 text-sm mb-2">
-              At the end of the round:
+              {t("rules.voting.description")}
             </p>
             <ul className="space-y-2 text-stone-400 text-sm">
               <li className="flex gap-3">
                 <span className="text-orange-500">•</span>
-                Players can vote to eliminate someone or skip the vote.
+                {t("rules.voting.item1")}
               </li>
               <li className="flex gap-3">
                 <span className="text-orange-500">•</span>
-                If a player gets the majority of votes, they are eliminated.
+                {t("rules.voting.item2")}
               </li>
             </ul>
           </section>
@@ -193,17 +195,17 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-green-500">
               <Trophy className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                End of the Game
+                {t("rules.end.title")}
               </h3>
             </div>
             <ul className="space-y-2 text-stone-400 text-sm">
               <li className="flex gap-3">
                 <span className="text-green-500">•</span>
-                If the impostor is caught → the players win.
+                {t("rules.end.item1")}
               </li>
               <li className="flex gap-3">
                 <span className="text-green-500">•</span>
-                If the impostor survives → the impostor wins.
+                {t("rules.end.item2")}
               </li>
             </ul>
           </section>
@@ -214,10 +216,9 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
               <Lightbulb className="w-5 h-5 text-yellow-500" />
             </div>
             <div>
-              <h4 className="font-bold text-white text-sm mb-1">Tip</h4>
+              <h4 className="font-bold text-white text-sm mb-1">{t("rules.tip.title")}</h4>
               <p className="text-stone-400 text-sm italic">
-                Draw enough to show you know the word… but don't make it too
-                obvious
+                {t("rules.tip.description")}
               </p>
             </div>
           </div>
@@ -229,7 +230,7 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             onClick={onClose}
             className="w-full py-3 bg-stone-800 hover:bg-stone-700 text-white font-bold rounded-xl transition-all active:scale-[0.98] cursor-pointer"
           >
-            GOT IT!
+            {t("rules.got_it")}
           </button>
         </div>
       </div>

--- a/src/components/VotingScreen.tsx
+++ b/src/components/VotingScreen.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
 import { useGameStore } from "../store/gameState";
 import { SkipForward, CheckCircle2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 export const VotingScreen: React.FC = () => {
+  const { t } = useTranslation();
   const players = useGameStore((state) => state.players);
   const playersRemaining = players.filter((p) => !p.isEjected);
   const myId = useGameStore((state) => state.myId);
@@ -27,17 +29,17 @@ export const VotingScreen: React.FC = () => {
       <div className="w-full max-w-2xl space-y-8">
         <div className="text-center space-y-2 mb-2">
           <h1 className="text-4xl text-white uppercase font-rubik-wet-paint font-extralight">
-            Voting Time
+            {t("voting.title")}
           </h1>
           <p className="text-stone-300 text-xl sm:text-2xl font-bold mb-7">
-            Round {currentRound}
+            {t("voting.round", { round: currentRound })}
           </p>
           <p
             className={`text-stone-400 text-base sm:text-lg tracking-wider font-semibold ${
               hasVoted ? "invisible" : "visible"
             }`}
           >
-            Who is the Inkpostor?
+            {t("voting.who_is")}
           </p>
         </div>
 
@@ -100,7 +102,7 @@ export const VotingScreen: React.FC = () => {
                 <span
                   className={`text-sm sm:text-lg font-semibold ${selectedPlayer === "skip" ? "text-white" : "text-stone-300"}`}
                 >
-                  Skip Vote
+                  {t("voting.skip")}
                 </span>
               </button>
               {!hasBeenEjected ? (
@@ -109,15 +111,15 @@ export const VotingScreen: React.FC = () => {
                   disabled={!selectedPlayer}
                   className="w-full py-3 rounded-xl bg-ink-primary hover:bg-ink-primary-accent text-white sm:text-xl text-lg disabled:opacity-50 transition-all active:scale-95 cursor-pointer font-extrabold"
                 >
-                  Confirm Vote
+                  {t("voting.confirm")}
                 </button>
               ) : (
                 <div className="w-full flex-col text-center flex items-center justify-center space-y-2">
                   <p className="text-ink-primary-accent text-sm sm:text-base font-bold">
-                    You have been ejected
+                    {t("voting.ejected")}
                   </p>
                   <p className="text-stone-400 animate-pulse text-sm sm:text-base">
-                    Waiting for other players to vote...
+                    {t("voting.waiting_others")}
                   </p>
                 </div>
               )}
@@ -126,9 +128,9 @@ export const VotingScreen: React.FC = () => {
         ) : (
           <div className=" bg-stone-800 rounded-3xl p-12 border border-stone-700 shadow-xl text-center flex flex-col items-center justify-center min-h-100">
             <CheckCircle2 className="w-20 h-20 text-emerald-500 mb-6" />
-            <h2 className="text-2xl font-bold text-white mb-2">Vote Cast!</h2>
+            <h2 className="text-2xl font-bold text-white mb-2">{t("voting.cast")}</h2>
             <p className="text-stone-400 animate-pulse">
-              Waiting for other players to vote...
+              {t("voting.waiting_others")}
             </p>
 
             <div className="mt-8 flex gap-2">
@@ -140,8 +142,7 @@ export const VotingScreen: React.FC = () => {
               ))}
             </div>
             <p className="text-sm text-stone-500 mt-4">
-              {Object.keys(votes).length} / {playersRemaining.length} votes
-              recorded
+              {t("voting.recorded", { count: Object.keys(votes).length, total: playersRemaining.length })}
             </p>
           </div>
         )}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,24 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+import enTranslation from './locales/en/translation.json';
+import esTranslation from './locales/es/translation.json';
+import caTranslation from './locales/ca/translation.json';
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: enTranslation },
+      es: { translation: esTranslation },
+      ca: { translation: caTranslation },
+    },
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+export default i18n;

--- a/src/i18n/locales/ca/translation.json
+++ b/src/i18n/locales/ca/translation.json
@@ -1,0 +1,116 @@
+{
+  "join": {
+    "your_name": "El teu Nom",
+    "enter_name": "Introdueix el teu nom",
+    "create_game": "Crear Nova Partida",
+    "or": "O",
+    "room_code": "Codi de Sala",
+    "eg_room": "P. ex. X7K9A2",
+    "join_game": "Unir-se a la Partida"
+  },
+  "lobby": {
+    "room_code": "Codi de Sala",
+    "copied": "Copiat!",
+    "click_to_copy": "Fes clic per copiar",
+    "waiting_room_code": "Esperant el codi de sala...",
+    "share_code": "Comparteix aquest codi amb els teus amics perquè s'uneixin!",
+    "players": "Jugadors",
+    "joined": "{{count}} / {{max}} units",
+    "full": "Sala plena",
+    "host": "Amfitrió",
+    "waiting_players": "Esperant més jugadors...",
+    "need_min": "Es necessiten almenys {{count}} jugadors per començar",
+    "start_game": "COMENÇAR PARTIDA",
+    "waiting_host": "Esperant que l'amfitrió comenci..."
+  },
+  "rules": {
+    "title": "Com Jugar a Inkpostor",
+    "got_it": "ENTÈS!",
+    "objective": {
+      "title": "Objectiu",
+      "description": "Descobreix qui és l'impostor... o enganya a tothom si ho ets tu."
+    },
+    "setup": {
+      "title": "Preparació",
+      "item1": "Cada jugador rep una paraula secreta.",
+      "item2": "Tots els jugadors reben la mateixa paraula, excepte l'impostor.",
+      "item3": "L'impostor rep només una pista relacionada, no la paraula exacta."
+    },
+    "drawing": {
+      "title": "Torns de Dibuix",
+      "item1": "El joc es desenvolupa per torns.",
+      "item2": "En cada torn, cada jugador dibuixa una part de la paraula.",
+      "item3": "El dibuix és compartit: tothom contribueix al mateix llenç."
+    },
+    "observe": {
+      "title": "Observa i Dedueix",
+      "item1": "Mentre dibuixes, intenta descobrir qui no coneix la paraula.",
+      "item2": "L'impostor ha de dibuixar amb cura per evitar sospites."
+    },
+    "voting": {
+      "title": "Fase de Votació",
+      "description": "Al final de la ronda:",
+      "item1": "Els jugadors poden votar per eliminar algú o saltar el vot.",
+      "item2": "Si un jugador rep la majoria de vots, és eliminat."
+    },
+    "end": {
+      "title": "Fi de la Partida",
+      "item1": "Si l'impostor és atrapat → els jugadors guanyen.",
+      "item2": "Si l'impostor sobreviu → l'impostor guanya."
+    },
+    "tip": {
+      "title": "Consell",
+      "description": "Dibuixa prou per demostrar que coneixes la paraula... però no ho facis massa obvi."
+    }
+  },
+  "role": {
+    "phase": "Fase 1",
+    "title": "El Teu Rol Secret",
+    "impostor": "Ets l'<br /> <span class=\"text-red-500\">Inkpostor</span>",
+    "hint": "Pista: {{category}}",
+    "word_is": "La paraula és",
+    "category": "Categoria: {{category}}",
+    "press_hold": "Mantén premut per revelar",
+    "make_sure": "Assegura't que tothom coneix el seu rol abans de continuar.",
+    "start_drawing": "Començar a Dibuixar",
+    "waiting_host": "Esperant que l'amfitrió comenci..."
+  },
+  "canvas": {
+    "your_turn": "El teu torn!",
+    "now_drawing": "Dibuixant ara",
+    "someone": "Algú",
+    "time": "Temps",
+    "done": "Fet",
+    "undo": "Desfés l'últim traç",
+    "ink_supply": "Subministrament de Tinta",
+    "out_of_ink": "SENSE TINTA!"
+  },
+  "voting": {
+    "title": "Temps de Votació",
+    "round": "Ronda {{round}}",
+    "who_is": "Qui és l'Inkpostor?",
+    "skip": "Saltar Vot",
+    "confirm": "Confirmar Vot",
+    "ejected": "Has estat expulsat",
+    "waiting_others": "Esperant que altres jugadors votin...",
+    "cast": "Vot Emès!",
+    "recorded": "{{count}} / {{total}} vots registrats"
+  },
+  "result": {
+    "defeated": "Inkpostor Derrotat",
+    "won": "L'Inkpostor ha Guanyat",
+    "vote_result": "Resultat de la votació",
+    "nobody_ejected": "Ningú ha estat expulsat...",
+    "ejected_was": "<span class=\"font-bold text-white\">{{name}}</span> ha estat expulsat.",
+    "still_among_us": "L'Inkpostor encara és entre nosaltres...",
+    "impostor_was": "<span class=\"font-bold text-white\">{{name}}</span> era l'Inkpostor!",
+    "secret_word": "La paraula secreta era",
+    "play_again": "Jugar de Nou",
+    "next_round": "Següent Ronda",
+    "waiting_host_restart": "Esperant que l'amfitrió reiniciï...",
+    "waiting_host_continue": "Esperant que l'amfitrió continuï..."
+  },
+  "common": {
+    "unknown_phase": "Fase de Joc Desconeguda: {{phase}}"
+  }
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1,0 +1,116 @@
+{
+  "join": {
+    "your_name": "Your Name",
+    "enter_name": "Enter your name",
+    "create_game": "Create New Game",
+    "or": "OR",
+    "room_code": "Room Code",
+    "eg_room": "E.g. X7K9A2",
+    "join_game": "Join Game"
+  },
+  "lobby": {
+    "room_code": "Room Code",
+    "copied": "Copied!",
+    "click_to_copy": "Click to copy",
+    "waiting_room_code": "Waiting for room code...",
+    "share_code": "Share this code with your friends to let them join!",
+    "players": "Players",
+    "joined": "{{count}} / {{max}} joined",
+    "full": "Full lobby",
+    "host": "Host",
+    "waiting_players": "Waiting for more players...",
+    "need_min": "Need at least {{count}} players to start",
+    "start_game": "START GAME",
+    "waiting_host": "Waiting for host to start..."
+  },
+  "rules": {
+    "title": "How to Play Inkpostor",
+    "got_it": "GOT IT!",
+    "objective": {
+      "title": "Objective",
+      "description": "Find out who the impostor is… or fool everyone if it's you."
+    },
+    "setup": {
+      "title": "Setup",
+      "item1": "Each player receives a secret word.",
+      "item2": "All players get the same word, except the impostor.",
+      "item3": "The impostor receives only a related hint, not the exact word."
+    },
+    "drawing": {
+      "title": "Drawing Turns",
+      "item1": "The game is played in turns.",
+      "item2": "In each turn, each player draws a part of the word.",
+      "item3": "The drawing is shared: everyone contributes to the same canvas."
+    },
+    "observe": {
+      "title": "Observe & Deduce",
+      "item1": "While drawing, try to figure out who doesn't know the word.",
+      "item2": "The impostor must draw carefully to avoid suspicion."
+    },
+    "voting": {
+      "title": "Voting Phase",
+      "description": "At the end of the round:",
+      "item1": "Players can vote to eliminate someone or skip the vote.",
+      "item2": "If a player gets the majority of votes, they are eliminated."
+    },
+    "end": {
+      "title": "End of the Game",
+      "item1": "If the impostor is caught → the players win.",
+      "item2": "If the impostor survives → the impostor wins."
+    },
+    "tip": {
+      "title": "Tip",
+      "description": "Draw enough to show you know the word… but don't make it too obvious"
+    }
+  },
+  "role": {
+    "phase": "Phase 1",
+    "title": "Your Secret Role",
+    "impostor": "You are the <br /> <span class=\"text-red-500\">Inkpostor</span>",
+    "hint": "Hint: {{category}}",
+    "word_is": "The word is",
+    "category": "Category: {{category}}",
+    "press_hold": "Press and hold to reveal",
+    "make_sure": "Make sure everyone knows their role before continuing.",
+    "start_drawing": "Start Drawing",
+    "waiting_host": "Waiting for Host to begin..."
+  },
+  "canvas": {
+    "your_turn": "Your turn!",
+    "now_drawing": "Now Drawing",
+    "someone": "Someone",
+    "time": "Time",
+    "done": "Done",
+    "undo": "Undo Last Stroke",
+    "ink_supply": "Ink Supply",
+    "out_of_ink": "OUT OF INK!"
+  },
+  "voting": {
+    "title": "Voting Time",
+    "round": "Round {{round}}",
+    "who_is": "Who is the Inkpostor?",
+    "skip": "Skip Vote",
+    "confirm": "Confirm Vote",
+    "ejected": "You have been ejected",
+    "waiting_others": "Waiting for other players to vote...",
+    "cast": "Vote Cast!",
+    "recorded": "{{count}} / {{total}} votes recorded"
+  },
+  "result": {
+    "defeated": "Inkpostor Defeated",
+    "won": "Inkpostor Won",
+    "vote_result": "Result of the vote",
+    "nobody_ejected": "Nobody was ejected...",
+    "ejected_was": "<span class=\"font-bold text-white\">{{name}}</span> was ejected.",
+    "still_among_us": "Inkpostor is still among us...",
+    "impostor_was": "<span class=\"font-bold text-white\">{{name}}</span> was the Inkpostor!",
+    "secret_word": "The secret word was",
+    "play_again": "Play Again",
+    "next_round": "Next Round",
+    "waiting_host_restart": "Waiting for host to restart...",
+    "waiting_host_continue": "Waiting for host to continue..."
+  },
+  "common": {
+    "unknown_phase": "Unknown Game Phase: {{phase}}"
+  }
+}

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -1,0 +1,116 @@
+{
+  "join": {
+    "your_name": "Nombre",
+    "enter_name": "Ingresa tu nombre",
+    "create_game": "Crear Nueva Partida",
+    "or": "O",
+    "room_code": "Código de Sala",
+    "eg_room": "Ej. X7K9A2",
+    "join_game": "Unirse a la Partida"
+  },
+  "lobby": {
+    "room_code": "Código de Sala",
+    "copied": "¡Copiado!",
+    "click_to_copy": "Haz clic para copiar",
+    "waiting_room_code": "Esperando el código de sala...",
+    "share_code": "¡Comparte este código con tus amigos para que se unan!",
+    "players": "Jugadores",
+    "joined": "{{count}} / {{max}} unidos",
+    "full": "Sala llena",
+    "host": "Anfitrión",
+    "waiting_players": "Esperando más jugadores...",
+    "need_min": "Se necesitan al menos {{count}} jugadores para empezar",
+    "start_game": "EMPEZAR PARTIDA",
+    "waiting_host": "Esperando a que el anfitrión empiece..."
+  },
+  "rules": {
+    "title": "Cómo Jugar Inkpostor",
+    "got_it": "¡ENTENDIDO!",
+    "objective": {
+      "title": "Objetivo",
+      "description": "Descubre quién es el impostor... o engaña a todos si eres tú."
+    },
+    "setup": {
+      "title": "Preparación",
+      "item1": "Cada jugador recibe una palabra secreta.",
+      "item2": "Todos los jugadores reciben la misma palabra, excepto el impostor.",
+      "item3": "El impostor recibe solo una pista relacionada, no la palabra exacta."
+    },
+    "drawing": {
+      "title": "Turnos de Dibujo",
+      "item1": "El juego se desarrolla por turnos.",
+      "item2": "En cada turno, cada jugador dibuja una parte de la palabra.",
+      "item3": "El dibujo es compartido: todos contribuyen al mismo lienzo."
+    },
+    "observe": {
+      "title": "Observa y Deduce",
+      "item1": "Mientras dibujas, intenta descubrir quién no conoce la palabra.",
+      "item2": "El impostor debe dibujar con cuidado para evitar sospechas."
+    },
+    "voting": {
+      "title": "Fase de Votación",
+      "description": "Al final de la ronda:",
+      "item1": "Los jugadores pueden votar para eliminar a alguien o saltar el voto.",
+      "item2": "Si un jugador recibe la mayoría de los votos, es eliminado."
+    },
+    "end": {
+      "title": "Fin de la Partida",
+      "item1": "Si el impostor es atrapado → los jugadores ganan.",
+      "item2": "Si el impostor sobrevive → el impostor gana."
+    },
+    "tip": {
+      "title": "Consejo",
+      "description": "Dibuja lo suficiente para demostrar que conoces la palabra... pero no lo hagas demasiado obvio."
+    }
+  },
+  "role": {
+    "phase": "Fase 1",
+    "title": "Tu Rol Secreto",
+    "impostor": "Eres el <br /> <span class=\"text-red-500\">Inkpostor</span>",
+    "hint": "Pista: {{category}}",
+    "word_is": "La palabra es",
+    "category": "Categoría: {{category}}",
+    "press_hold": "Mantén presionado para revelar",
+    "make_sure": "Asegúrate de que todos conozcan su rol antes de continuar.",
+    "start_drawing": "Empezar a Dibujar",
+    "waiting_host": "Esperando a que el anfitrión comience..."
+  },
+  "canvas": {
+    "your_turn": "¡Tu turno!",
+    "now_drawing": "Dibujando ahora",
+    "someone": "Alguien",
+    "time": "Tiempo",
+    "done": "Listo",
+    "undo": "Deshacer último trazo",
+    "ink_supply": "Suministro de Tinta",
+    "out_of_ink": "¡SIN TINTA!"
+  },
+  "voting": {
+    "title": "Tiempo de Votación",
+    "round": "Ronda {{round}}",
+    "who_is": "¿Quién es el Inkpostor?",
+    "skip": "Saltar Voto",
+    "confirm": "Confirmar Voto",
+    "ejected": "Has sido expulsado",
+    "waiting_others": "Esperando a que otros jugadores voten...",
+    "cast": "¡Voto Emitido!",
+    "recorded": "{{count}} / {{total}} votos registrados"
+  },
+  "result": {
+    "defeated": "Inkpostor Derrotado",
+    "won": "Inkpostor Ganó",
+    "vote_result": "Resultado de la votación",
+    "nobody_ejected": "Nadie fue expulsado...",
+    "ejected_was": "<span class=\"font-bold text-white\">{{name}}</span> fue expulsado.",
+    "still_among_us": "El Inkpostor todavía está entre nosotros...",
+    "impostor_was": "¡<span class=\"font-bold text-white\">{{name}}</span> era el Inkpostor!",
+    "secret_word": "La palabra secreta era",
+    "play_again": "Jugar de Nuevo",
+    "next_round": "Siguiente Ronda",
+    "waiting_host_restart": "Esperando a que el anfitrión reinicie...",
+    "waiting_host_continue": "Esperando a que el anfitrión continúe..."
+  },
+  "common": {
+    "unknown_phase": "Fase de Juego Desconocida: {{phase}}"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from "react-dom/client";
 import "./index.css";
+import "./i18n";
 import App from "./App.tsx";
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,1 +1,34 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+// Mock i18next and react-i18next
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: any) => {
+        return key;
+    },
+    i18n: {
+      changeLanguage: () => Promise.resolve(),
+      language: "en",
+    },
+  }),
+  initReactI18next: {
+    type: "3rdParty",
+    init: () => {},
+  },
+  Trans: ({ children, i18nKey }: any) => {
+      // In RoleReveal.test.tsx, it's expecting "Inkpostor" but the key is "role.impostor"
+      // In GameResult.test.tsx, it's expecting the name "Impostor" or "Player 3"
+      // The current Trans implementation in components might be causing issues if mocked like this
+      return children || i18nKey;
+  }
+}));
+
+vi.mock("i18next", () => ({
+  default: {
+    use: () => ({
+      init: () => {},
+    }),
+    t: (key: string) => key,
+  },
+}));

--- a/tests/components/Canvas.test.tsx
+++ b/tests/components/Canvas.test.tsx
@@ -56,16 +56,16 @@ describe("Canvas", () => {
     render(<Canvas />);
 
     // Header
-    expect(screen.getByText("Your turn!")).toBeInTheDocument();
+    expect(screen.getByText("canvas.your_turn")).toBeInTheDocument();
     expect(screen.getByText("Host")).toBeInTheDocument();
 
     // Should display time
     expect(screen.getByText("15.0s")).toBeInTheDocument();
 
     // Tools
-    expect(screen.getByTitle("Undo Last Stroke")).toBeInTheDocument();
-    expect(screen.getByText("Ink Supply")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /done/i })).toBeInTheDocument();
+    expect(screen.getByTitle("canvas.undo")).toBeInTheDocument();
+    expect(screen.getByText("canvas.ink_supply")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /canvas\.done/i })).toBeInTheDocument();
   });
 
   it("renders waiting UI for non-active players", () => {
@@ -77,14 +77,14 @@ describe("Canvas", () => {
     render(<Canvas />);
 
     // Header
-    expect(screen.getByText("Now Drawing")).toBeInTheDocument();
+    expect(screen.getByText("canvas.now_drawing")).toBeInTheDocument();
     expect(screen.getByText("Host")).toBeInTheDocument();
 
     // Shouldn't see tools
-    expect(screen.queryByTitle("Undo Last Stroke")).not.toBeInTheDocument();
-    expect(screen.queryByText("Ink Supply")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("canvas.undo")).not.toBeInTheDocument();
+    expect(screen.queryByText("canvas.ink_supply")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /done/i }),
+      screen.queryByRole("button", { name: /canvas\.done/i }),
     ).not.toBeInTheDocument();
   });
 
@@ -96,7 +96,7 @@ describe("Canvas", () => {
 
     render(<Canvas />);
 
-    const doneBtn = screen.getByRole("button", { name: /done/i });
+    const doneBtn = screen.getByRole("button", { name: /canvas\.done/i });
     fireEvent.click(doneBtn);
     expect(mockEndTurn).toHaveBeenCalled();
   });
@@ -109,7 +109,7 @@ describe("Canvas", () => {
 
     render(<Canvas />);
 
-    const undoBtn = screen.getByTitle("Undo Last Stroke");
+    const undoBtn = screen.getByTitle("canvas.undo");
     expect(undoBtn).toBeInTheDocument();
   });
 });

--- a/tests/components/GameResult.test.tsx
+++ b/tests/components/GameResult.test.tsx
@@ -46,10 +46,10 @@ describe("GameResult", () => {
 
     render(<GameResult />);
 
-    expect(screen.getByText("Inkpostor Defeated")).toBeInTheDocument();
+    expect(screen.getByText("result.defeated")).toBeInTheDocument();
 
-    // Use getAllByText for 'Impostor' since it appears twice
-    // (Once as ejected player, once as the inkpostor text)
+    // Since our mock Trans returns children if present
+    // It will render the children of Trans components which contain names
     const impostorTexts = screen.getAllByText("Impostor");
     expect(impostorTexts).toHaveLength(2);
 
@@ -76,7 +76,7 @@ describe("GameResult", () => {
 
     render(<GameResult />);
 
-    expect(screen.getByText("Inkpostor Won")).toBeInTheDocument();
+    expect(screen.getByText("result.won")).toBeInTheDocument();
     expect(screen.getByText("Player 3")).toBeInTheDocument(); // Ejected name
     expect(screen.getByText("Impostor")).toBeInTheDocument(); // Was the inkpostor
   });
@@ -95,7 +95,7 @@ describe("GameResult", () => {
 
     render(<GameResult />);
 
-    expect(screen.getByText("Nobody was ejected...")).toBeInTheDocument();
+    expect(screen.getByText("result.nobody_ejected")).toBeInTheDocument();
   });
 
   it("allows host to play again", () => {
@@ -110,7 +110,7 @@ describe("GameResult", () => {
 
     render(<GameResult />);
 
-    const playAgainBtn = screen.getByRole("button", { name: /play again/i });
+    const playAgainBtn = screen.getByRole("button", { name: /result\.play_again/i });
     fireEvent.click(playAgainBtn);
     expect(mockPlayAgain).toHaveBeenCalled();
   });
@@ -129,10 +129,10 @@ describe("GameResult", () => {
     render(<GameResult />);
 
     expect(
-      screen.queryByRole("button", { name: /play again/i }),
+      screen.queryByRole("button", { name: /result\.play_again/i }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText("Waiting for host to restart..."),
+      screen.getByText("result.waiting_host_restart"),
     ).toBeInTheDocument();
   });
 });

--- a/tests/components/JoinScreen.test.tsx
+++ b/tests/components/JoinScreen.test.tsx
@@ -30,13 +30,13 @@ describe("JoinScreen", () => {
   it("renders the initial screen with inputs and buttons", () => {
     render(<JoinScreen />);
 
-    expect(screen.getByPlaceholderText("Enter your name")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("join.enter_name")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /create new game/i }),
+      screen.getByRole("button", { name: /join.create_game/i }),
     ).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("E.g. X7K9A2")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("join.eg_room")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /join game/i }),
+      screen.getByRole("button", { name: /join.join_game/i }),
     ).toBeInTheDocument();
   });
 
@@ -44,7 +44,7 @@ describe("JoinScreen", () => {
     render(<JoinScreen />);
 
     const createButton = screen.getByRole("button", {
-      name: /create new game/i,
+      name: /join.create_game/i,
     });
     expect(createButton).toBeDisabled();
   });
@@ -53,9 +53,9 @@ describe("JoinScreen", () => {
     const user = userEvent.setup();
     render(<JoinScreen />);
 
-    const nameInput = screen.getByPlaceholderText("Enter your name");
+    const nameInput = screen.getByPlaceholderText("join.enter_name");
     const createButton = screen.getByRole("button", {
-      name: /create new game/i,
+      name: /join.create_game/i,
     });
 
     await user.type(nameInput, "Player1");
@@ -72,9 +72,9 @@ describe("JoinScreen", () => {
     const user = userEvent.setup();
     render(<JoinScreen />);
 
-    const nameInput = screen.getByPlaceholderText("Enter your name");
-    const roomInput = screen.getByPlaceholderText("E.g. X7K9A2");
-    const joinButton = screen.getByRole("button", { name: /join game/i });
+    const nameInput = screen.getByPlaceholderText("join.enter_name");
+    const roomInput = screen.getByPlaceholderText("join.eg_room");
+    const joinButton = screen.getByRole("button", { name: /join.join_game/i });
 
     expect(joinButton).toBeDisabled();
 
@@ -90,9 +90,9 @@ describe("JoinScreen", () => {
     const user = userEvent.setup();
     render(<JoinScreen />);
 
-    const nameInput = screen.getByPlaceholderText("Enter your name");
-    const roomInput = screen.getByPlaceholderText("E.g. X7K9A2");
-    const joinButton = screen.getByRole("button", { name: /join game/i });
+    const nameInput = screen.getByPlaceholderText("join.enter_name");
+    const roomInput = screen.getByPlaceholderText("join.eg_room");
+    const joinButton = screen.getByRole("button", { name: /join.join_game/i });
 
     await user.type(nameInput, "Player1");
     await user.type(roomInput, "room12");

--- a/tests/components/Lobby.test.tsx
+++ b/tests/components/Lobby.test.tsx
@@ -46,13 +46,13 @@ describe("Lobby", () => {
     });
 
     render(<Lobby />);
-    expect(screen.getByText("Waiting for more players...")).toBeInTheDocument();
+    expect(screen.getByText("lobby.waiting_players")).toBeInTheDocument();
     expect(
-      screen.getByText("Need at least 3 players to start"),
+      screen.getByText("lobby.need_min"),
     ).toBeInTheDocument();
 
     // Start Game button should be disabled for the host
-    const startButton = screen.getByRole("button", { name: /start game/i });
+    const startButton = screen.getByRole("button", { name: /lobby\.start_game/i });
     expect(startButton).toBeDisabled();
   });
 
@@ -73,7 +73,7 @@ describe("Lobby", () => {
     render(<Lobby />);
 
     // Start Game button should be enabled
-    const startButton = screen.getByRole("button", { name: /start game/i });
+    const startButton = screen.getByRole("button", { name: /lobby\.start_game/i });
     expect(startButton).toBeEnabled();
 
     await user.click(startButton);
@@ -97,10 +97,10 @@ describe("Lobby", () => {
     render(<Lobby />);
 
     expect(
-      screen.queryByRole("button", { name: /start game/i }),
+      screen.queryByRole("button", { name: /lobby\.start_game/i }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText("Waiting for host to start..."),
+      screen.getByText("lobby.waiting_host"),
     ).toBeInTheDocument();
   });
 
@@ -125,7 +125,7 @@ describe("Lobby", () => {
     await user.click(copyButton);
 
     expect(writeTextMock).toHaveBeenCalledWith("TESTX9");
-    expect(screen.getByText("Copied!")).toBeInTheDocument();
+    expect(screen.getByText("lobby.copied")).toBeInTheDocument();
   });
 
   it("disables the copy button and shows placeholder when roomId is null", () => {
@@ -137,11 +137,11 @@ describe("Lobby", () => {
     render(<Lobby />);
 
     const copyButton = screen.getByRole("button", {
-      name: /Waiting for room code\.\.\./i,
+      name: /lobby\.waiting_room_code/i,
     });
     expect(copyButton).toBeDisabled();
     expect(screen.getByText("------")).toBeInTheDocument();
-    expect(copyButton).toHaveAttribute("title", "Room code not ready");
+    expect(copyButton).toHaveAttribute("title", "lobby.waiting_room_code");
   });
 
   it("opens the rules modal when the how to play button is clicked", async () => {
@@ -156,12 +156,12 @@ describe("Lobby", () => {
     const howToPlayBtn = screen.getByTestId("how-to-play-btn");
     await user.click(howToPlayBtn);
 
-    expect(screen.getByText("How to Play Inkpostor")).toBeInTheDocument();
-    expect(screen.getByText("Objective")).toBeInTheDocument();
+    expect(screen.getByText("rules.title")).toBeInTheDocument();
+    expect(screen.getByText("rules.objective.title")).toBeInTheDocument();
 
-    const closeBtn = screen.getByText("GOT IT!");
+    const closeBtn = screen.getByText("rules.got_it");
     await user.click(closeBtn);
 
-    expect(screen.queryByText("How to Play Inkpostor")).not.toBeInTheDocument();
+    expect(screen.queryByText("rules.title")).not.toBeInTheDocument();
   });
 });

--- a/tests/components/RoleReveal.test.tsx
+++ b/tests/components/RoleReveal.test.tsx
@@ -33,11 +33,11 @@ describe("RoleReveal", () => {
 
     render(<RoleReveal />);
 
-    expect(screen.getByText("Phase 1")).toBeInTheDocument();
-    expect(screen.getByText("Your Secret Role")).toBeInTheDocument();
-    expect(screen.getByText("Press and hold to reveal")).toBeInTheDocument();
+    expect(screen.getByText("role.phase")).toBeInTheDocument();
+    expect(screen.getByText("role.title")).toBeInTheDocument();
+    expect(screen.getByText("role.press_hold")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /start drawing/i }),
+      screen.getByRole("button", { name: /role\.start_drawing/i }),
     ).toBeInTheDocument();
   });
 
@@ -51,7 +51,7 @@ describe("RoleReveal", () => {
 
     // The reveal button is the one containing 'Press and hold to reveal'
     const revealButton = screen
-      .getByText("Press and hold to reveal")
+      .getByText("role.press_hold")
       .closest("button");
     expect(revealButton).not.toBeNull();
 
@@ -59,9 +59,9 @@ describe("RoleReveal", () => {
     fireEvent.mouseDown(revealButton!);
 
     // Word and category should be visible
-    expect(screen.getByText("The word is")).toBeInTheDocument();
+    expect(screen.getByText("role.word_is")).toBeInTheDocument();
     expect(screen.getByText("Elephant")).toBeInTheDocument();
-    expect(screen.getByText("Category: Animals")).toBeInTheDocument();
+    expect(screen.getByText("role.category")).toBeInTheDocument();
   });
 
   it("reveals impostor status when clicked for impostors", () => {
@@ -73,14 +73,15 @@ describe("RoleReveal", () => {
     render(<RoleReveal />);
 
     const revealButton = screen
-      .getByText("Press and hold to reveal")
+      .getByText("role.press_hold")
       .closest("button");
     expect(revealButton).not.toBeNull();
 
     fireEvent.mouseDown(revealButton!);
 
-    expect(screen.getByText("Inkpostor")).toBeInTheDocument();
-    expect(screen.getByText("Hint: Animals")).toBeInTheDocument();
+    // Since our mock Trans returns children if present, and "Inkpostor" is within <span>
+    expect(screen.getByText(/Inkpostor/i)).toBeInTheDocument();
+    expect(screen.getByText("role.hint")).toBeInTheDocument();
   });
 
   it("allows the host to start drawing", () => {
@@ -91,7 +92,7 @@ describe("RoleReveal", () => {
 
     render(<RoleReveal />);
 
-    const startButton = screen.getByRole("button", { name: /start drawing/i });
+    const startButton = screen.getByRole("button", { name: /role\.start_drawing/i });
     fireEvent.click(startButton);
 
     expect(mockProceedToDrawing).toHaveBeenCalled();
@@ -106,10 +107,10 @@ describe("RoleReveal", () => {
     render(<RoleReveal />);
 
     expect(
-      screen.queryByRole("button", { name: /start drawing!/i }),
+      screen.queryByRole("button", { name: /role\.start_drawing!/i }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText("Waiting for Host to begin..."),
+      screen.getByText("role.waiting_host"),
     ).toBeInTheDocument();
   });
 });

--- a/tests/components/VotingScreen.test.tsx
+++ b/tests/components/VotingScreen.test.tsx
@@ -40,7 +40,7 @@ describe("VotingScreen", () => {
     // Should see other players
     expect(screen.getByText("Player 2")).toBeInTheDocument();
     expect(screen.getByText("Player 3")).toBeInTheDocument();
-    expect(screen.getByText("Skip Vote")).toBeInTheDocument();
+    expect(screen.getByText("voting.skip")).toBeInTheDocument();
   });
 
   it("disables confirm button initially and enables it when a player is selected", () => {
@@ -51,7 +51,7 @@ describe("VotingScreen", () => {
 
     render(<VotingScreen />);
 
-    const confirmBtn = screen.getByRole("button", { name: /confirm vote/i });
+    const confirmBtn = screen.getByRole("button", { name: /voting\.confirm/i });
     expect(confirmBtn).toBeDisabled();
 
     // Select Player 2
@@ -59,7 +59,7 @@ describe("VotingScreen", () => {
     expect(confirmBtn).toBeEnabled();
 
     // Select Skip
-    fireEvent.click(screen.getByText("Skip Vote"));
+    fireEvent.click(screen.getByText("voting.skip"));
     expect(confirmBtn).toBeEnabled();
   });
 
@@ -75,7 +75,7 @@ describe("VotingScreen", () => {
     const playerBtn = screen.getByText("Player 2").closest("button");
     fireEvent.click(playerBtn!);
 
-    const confirmBtn = screen.getByRole("button", { name: /confirm vote/i });
+    const confirmBtn = screen.getByRole("button", { name: /voting\.confirm/i });
     fireEvent.click(confirmBtn);
 
     expect(mockVote).toHaveBeenCalledWith("socket-456");
@@ -95,12 +95,12 @@ describe("VotingScreen", () => {
 
     render(<VotingScreen />);
 
-    expect(screen.getByText("Vote Cast!")).toBeInTheDocument();
+    expect(screen.getByText("voting.cast")).toBeInTheDocument();
     expect(
-      screen.getByText("Waiting for other players to vote..."),
+      screen.getByText("voting.waiting_others"),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /confirm vote/i }),
+      screen.queryByRole("button", { name: /voting\.confirm/i }),
     ).not.toBeInTheDocument();
   });
 
@@ -145,9 +145,9 @@ describe("VotingScreen", () => {
 
     render(<VotingScreen />);
 
-    expect(screen.getByText("You have been ejected")).toBeInTheDocument();
+    expect(screen.getByText("voting.ejected")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /confirm vote/i }),
+      screen.queryByRole("button", { name: /voting\.confirm/i }),
     ).not.toBeInTheDocument();
 
     // Other players should be disabled


### PR DESCRIPTION
This change adds internationalization support to the Inkpostor frontend. It introduces the `i18next` library and provides complete translations for the three requested languages: English, Spanish, and Catalan. All user-facing strings in components like the Lobby, Canvas, Voting Screen, and Game Results have been moved to translation files. A language selector has been added to the Join screen to allow users to switch languages easily. The test suite has also been updated to handle the i18n integration correctly by mocking the translation functions.

Fixes #14

---
*PR created automatically by Jules for task [2387330913837595032](https://jules.google.com/task/2387330913837595032) started by @jorbush*