### PR TITLE
Increase draw time from 15 to 20 seconds

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useGameStore } from "../store/gameState";
 import { Undo, CheckSquare, Clock } from "lucide-react";
+import { TURN_TIME_MS } from "../lib/constants";
 
 export const Canvas: React.FC = () => {
   const { t } = useTranslation();
@@ -14,7 +15,6 @@ export const Canvas: React.FC = () => {
   // Limits
   const MAX_INK = 1000;
   const DOT_INK_COST = 5;
-  const TURN_TIME_MS = 15000; // 15 seconds
   const [inkUsed, setInkUsed] = useState(0);
   const [timeLeft, setTimeLeft] = useState(TURN_TIME_MS);
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,2 +1,3 @@
 export const MAX_PLAYERS = 10;
 export const MIN_PLAYERS = 3;
+export const TURN_TIME_MS = 20000;

--- a/tests/components/Canvas.test.tsx
+++ b/tests/components/Canvas.test.tsx
@@ -60,7 +60,7 @@ describe("Canvas", () => {
     expect(screen.getByText("Host")).toBeInTheDocument();
 
     // Should display time
-    expect(screen.getByText("15.0s")).toBeInTheDocument();
+    expect(screen.getByText("20.0s")).toBeInTheDocument();
 
     // Tools
     expect(screen.getByTitle("Undo Last Stroke")).toBeInTheDocument();


### PR DESCRIPTION
This PR increases the drawing turn duration from 15 seconds to 20 seconds. It also refactors the code by moving the `TURN_TIME_MS` constant from a local variable in the `Canvas` component to a centralized `src/lib/constants.ts` file for better maintainability. Unit tests have been updated and verified to ensure the UI reflects the new time limit correctly.

Fixes #55

---
*PR created automatically by Jules for task [1044072777418228643](https://jules.google.com/task/1044072777418228643) started by @jorbush*