### PR TITLE
Rename "server" variables and constants to "service"

### DIFF
--- a/src/components/JoinScreen.tsx
+++ b/src/components/JoinScreen.tsx
@@ -2,27 +2,27 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useGameStore } from "../store/gameState";
 import { Users } from "lucide-react";
-import { SERVER_URL } from "../socket";
+import { SERVICE_URL } from "../socket";
 
 export const JoinScreen: React.FC = () => {
   const { t } = useTranslation();
   const [playerName, setPlayerName] = useState("");
   const [roomId, setRoomId] = useState("");
   const [isCheckingHealth, setIsCheckingHealth] = useState(true);
-  const [serverOnline, setServerOnline] = useState(false);
+  const [serviceOnline, setServiceOnline] = useState(false);
   const actions = useGameStore((state) => state.actions);
   const errorMessage = useGameStore((state) => state.errorMessage);
 
   const handleCreate = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!playerName || !serverOnline) return;
+    if (!playerName || !serviceOnline) return;
     const newRoomId = Math.random().toString(36).substring(2, 8).toUpperCase();
     actions.connectAndCreate(newRoomId, playerName);
   };
 
   const handleJoin = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!playerName || !roomId || !serverOnline) return;
+    if (!playerName || !roomId || !serviceOnline) return;
     actions.connectAndJoin(roomId.toUpperCase(), playerName);
   };
 
@@ -30,17 +30,17 @@ export const JoinScreen: React.FC = () => {
     const checkHealth = async () => {
       setIsCheckingHealth(true);
       try {
-        const res = await fetch(`${SERVER_URL || ""}/health`, {
+        const res = await fetch(`${SERVICE_URL || ""}/health`, {
           method: "GET",
         });
 
         if (res.ok) {
-          setServerOnline(true);
+          setServiceOnline(true);
         } else {
-          setServerOnline(false);
+          setServiceOnline(false);
         }
       } catch {
-        setServerOnline(false);
+        setServiceOnline(false);
       } finally {
         setIsCheckingHealth(false);
       }
@@ -66,7 +66,7 @@ export const JoinScreen: React.FC = () => {
           </div>
         )}
 
-        {serverOnline || isCheckingHealth ? (
+        {serviceOnline || isCheckingHealth ? (
           <div className="bg-stone-800 p-6 rounded-2xl shadow-xl border border-stone-700 space-y-6 animate-fade-in-up">
             <div className="space-y-4">
               <div>
@@ -134,7 +134,7 @@ export const JoinScreen: React.FC = () => {
         ) : (
           <div className="flex  gap-3 justify-center animate-fade-in animate-duration-slower animate-delay-400 min-h-100.5">
             <span className="text-xl font-rubik-wet-paint font-extralight text-red-700 mt-10 ">
-              {t("join.serverOffline")}
+              {t("join.serviceOffline")}
             </span>
           </div>
         )}
@@ -144,7 +144,7 @@ export const JoinScreen: React.FC = () => {
           <div className="flex items-center gap-2 mt-2.5">
             <div className="w-2 h-2 bg-yellow-400 rounded-full animate-pulse"></div>
             <span className="text-sm text-stone-400">
-              {t("join.checkingServer")}
+              {t("join.checkingService")}
             </span>
           </div>
         )}

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -8,8 +8,8 @@
       "roomCode": "Codi de Sala",
       "roomCodePlaceholder": "Ex. X7K9A2",
       "joinGame": "Unir-se",
-      "checkingServer": "Comprovant l'estat del servei...",
-      "serverOffline": "El servei no està disponible en aquest moment"
+      "checkingService": "Comprovant l'estat del servei...",
+      "serviceOffline": "El servei no està disponible en aquest moment"
     },
     "lobby": {
       "roomCode": "Codi de Sala",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -8,8 +8,8 @@
       "roomCode": "Room Code",
       "roomCodePlaceholder": "E.g. X7K9A2",
       "joinGame": "Join Game",
-      "checkingServer": "Checking the service status...",
-      "serverOffline": "The service is currently unavailable"
+      "checkingService": "Checking the service status...",
+      "serviceOffline": "The service is currently unavailable"
     },
     "lobby": {
       "roomCode": "Room Code",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -8,8 +8,8 @@
       "roomCode": "Código de Sala",
       "roomCodePlaceholder": "Ej. X7K9A2",
       "joinGame": "Unirse",
-      "checkingServer": "Comprobando el estado del servicio...",
-      "serverOffline": "El servicio no está disponible en este momento"
+      "checkingService": "Comprobando el estado del servicio...",
+      "serviceOffline": "El servicio no está disponible en este momento"
     },
     "lobby": {
       "roomCode": "Código de Sala",

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -1,10 +1,10 @@
 import { io } from "socket.io-client";
 
-// the server runs on 3001 locally, can be overridden by VITE_BACKEND_URL
-export const SERVER_URL =
+// the service runs on 3001 locally, can be overridden by VITE_BACKEND_URL
+export const SERVICE_URL =
   import.meta.env.VITE_BACKEND_URL ||
   (import.meta.env.MODE === "production" ? undefined : "http://localhost:3001");
 
-export const socket = io(SERVER_URL as string, {
+export const socket = io(SERVICE_URL as string, {
   autoConnect: false, // Wait until user joins
 });

--- a/src/store/gameState.ts
+++ b/src/store/gameState.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { socket, SERVER_URL } from "../socket";
+import { socket, SERVICE_URL } from "../socket";
 
 function detectIsMobile(): boolean {
   if (typeof navigator === "undefined") return false;
@@ -107,7 +107,7 @@ export const useGameStore = create<GameState>()((set) => ({
     connectAndCreate: async (roomId, playerName) => {
       try {
         const userId = getOrCreateUserId();
-        const res = await fetch(`${SERVER_URL || ""}/auth`, {
+        const res = await fetch(`${SERVICE_URL || ""}/auth`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ username: playerName, userId }),
@@ -123,13 +123,13 @@ export const useGameStore = create<GameState>()((set) => ({
         socket.emit("createRoom", { roomId });
         set({ myName: playerName, myId: userId });
       } catch {
-        set({ errorMessage: "Server connection error." });
+        set({ errorMessage: "Service connection error." });
       }
     },
     connectAndJoin: async (roomId, playerName) => {
       try {
         const userId = getOrCreateUserId();
-        const res = await fetch(`${SERVER_URL || ""}/auth`, {
+        const res = await fetch(`${SERVICE_URL || ""}/auth`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ username: playerName, userId }),
@@ -145,7 +145,7 @@ export const useGameStore = create<GameState>()((set) => ({
         socket.emit("joinRoom", { roomId });
         set({ myName: playerName, myId: userId });
       } catch {
-        set({ errorMessage: "Server connection error." });
+        set({ errorMessage: "Service connection error." });
       }
     },
     startGame: () => {
@@ -197,15 +197,15 @@ socket.on("connect", () => {
 });
 
 socket.on("gameStateUpdate", (newState) => {
-  // Sync all server-provided state that exists on client state
+  // Sync all service-provided state that exists on client state
   useGameStore.setState((state) => ({
     ...state,
     roomId: newState.roomId,
     hostId: newState.hostId,
     phase: newState.phase,
     players: newState.players,
-    impostorId: newState.impostorId, // Usually null from server until RESULTS
-    secretWord: newState.secretWord, // Usually null from server unless RESULTS
+    impostorId: newState.impostorId, // Usually null from service until RESULTS
+    secretWord: newState.secretWord, // Usually null from service unless RESULTS
     secretCategory: newState.secretCategory,
     currentTurnPlayerId: newState.currentTurnPlayerId,
     turnOrder: newState.turnOrder,

--- a/tests/components/JoinScreen.test.tsx
+++ b/tests/components/JoinScreen.test.tsx
@@ -59,7 +59,7 @@ describe("JoinScreen", () => {
     expect(createButton).toBeDisabled();
   });
 
-  it("disables inputs and buttons while checking server health", async () => {
+  it("disables inputs and buttons while checking service health", async () => {
     (global.fetch as any).mockImplementation(
       () =>
         new Promise(() => {
@@ -120,7 +120,7 @@ describe("JoinScreen", () => {
     );
   });
 
-  it("disables create button even with name entered while server is offline", async () => {
+  it("disables create button even with name entered while service is offline", async () => {
     (global.fetch as any).mockResolvedValueOnce({
       ok: false,
     });
@@ -210,7 +210,7 @@ describe("JoinScreen", () => {
     ).toBeInTheDocument();
   });
 
-  describe("Server Health Check", () => {
+  describe("Service Health Check", () => {
     it("shows 'Checking the service status...' on initial render", async () => {
       (global.fetch as any).mockImplementation(
         () =>
@@ -226,7 +226,7 @@ describe("JoinScreen", () => {
       ).toBeInTheDocument();
     });
 
-    it("hides form and shows offline message when server check completes and server is offline", async () => {
+    it("hides form and shows offline message when service check completes and service is offline", async () => {
       (global.fetch as any).mockResolvedValueOnce({
         ok: false,
       });

--- a/tests/store/gameState.test.ts
+++ b/tests/store/gameState.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../src/socket", () => ({
     id: "test-socket-id",
     auth: {},
   },
-  SERVER_URL: "http://localhost:3000",
+  SERVICE_URL: "http://localhost:3000",
 }));
 
 global.fetch = vi.fn();


### PR DESCRIPTION
I have renamed all variables, constants, and internationalization keys that previously used the term "server" to use "service" instead. This refactoring ensures a consistent naming convention throughout the frontend codebase and its associated tests. The changes include updating `SERVICE_URL`, `serviceOnline`, and the relevant translation keys in English, Spanish, and Catalan locales. I have verified that all tests pass and that no instances of the word "server" (case-insensitive) remain in the source or test directories.

Fixes #51

---
*PR created automatically by Jules for task [5915320692922774446](https://jules.google.com/task/5915320692922774446) started by @jorbush*