### PR TITLE
Fix "How to Play" translations and accessibility

### DIFF
--- a/src/components/JoinScreen.tsx
+++ b/src/components/JoinScreen.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useGameStore } from "../store/gameState";
-import { Users } from "lucide-react";
+import { Users, HelpCircle } from "lucide-react";
 import { SERVICE_URL } from "../socket";
+import { RulesModal } from "./RulesModal";
 
 export const JoinScreen: React.FC = () => {
   const { t } = useTranslation();
@@ -10,6 +11,7 @@ export const JoinScreen: React.FC = () => {
   const [roomId, setRoomId] = useState("");
   const [isCheckingHealth, setIsCheckingHealth] = useState(true);
   const [serviceOnline, setServiceOnline] = useState(false);
+  const [isRulesOpen, setIsRulesOpen] = useState(false);
   const actions = useGameStore((state) => state.actions);
   const errorMessage = useGameStore((state) => state.errorMessage);
 
@@ -52,12 +54,20 @@ export const JoinScreen: React.FC = () => {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-4 bg-stone-900">
       <div className="max-w-md w-full text-center space-y-8">
-        <div className="inline-flex items-center justify-center">
+        <div className="inline-flex items-center justify-center relative">
           <img
             src="/inkpostor-logo.webp"
             alt="Inkpostor Logo"
             className=" h-42 animate-zoom-in"
           />
+          <button
+            onClick={() => setIsRulesOpen(true)}
+            className="absolute -right-12 top-1/2 -translate-y-1/2 p-2 text-stone-400 hover:text-white transition-colors cursor-pointer"
+            title={t("rules.title")}
+            data-testid="how-to-play-btn"
+          >
+            <HelpCircle className="w-8 h-8" />
+          </button>
         </div>
 
         {errorMessage && (
@@ -149,6 +159,7 @@ export const JoinScreen: React.FC = () => {
           </div>
         )}
       </div>
+      <RulesModal isOpen={isRulesOpen} onClose={() => setIsRulesOpen(false)} />
     </div>
   );
 };

--- a/src/components/RulesModal.tsx
+++ b/src/components/RulesModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import {
   X,
   HelpCircle,
@@ -17,6 +18,7 @@ interface RulesModalProps {
 }
 
 export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
+  const { t } = useTranslation();
   const modalRef = useRef<HTMLDivElement>(null);
   const previousFocus = useRef<HTMLElement | null>(null);
 
@@ -70,7 +72,7 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
               id="rules-title"
               className="text-2xl font-extralight text-white font-rubik-wet-paint tracking-wide"
             >
-              How to Play Inkpostor
+              {t("rules.title")}
             </h2>
           </div>
           <button
@@ -89,11 +91,11 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-ink-primary">
               <Target className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                Objective
+                {t("rules.objective.title")}
               </h3>
             </div>
             <p className="text-stone-300 leading-relaxed">
-              Find out who the impostor is… or fool everyone if it's you.
+              {t("rules.objective.description")}
             </p>
           </section>
 
@@ -102,21 +104,21 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-amber-500">
               <Settings className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                Setup
+                {t("rules.setup.title")}
               </h3>
             </div>
             <ul className="space-y-2 text-stone-400 text-sm">
               <li className="flex gap-3">
                 <span className="text-amber-500">•</span>
-                Each player receives a secret word.
+                {t("rules.setup.item1")}
               </li>
               <li className="flex gap-3">
                 <span className="text-amber-500">•</span>
-                All players get the same word, except the impostor.
+                {t("rules.setup.item2")}
               </li>
               <li className="flex gap-3">
                 <span className="text-amber-500">•</span>
-                The impostor receives only a related hint, not the exact word.
+                {t("rules.setup.item3")}
               </li>
             </ul>
           </section>
@@ -126,21 +128,21 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-blue-500">
               <PenTool className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                Drawing Turns
+                {t("rules.drawing.title")}
               </h3>
             </div>
             <ul className="space-y-2 text-stone-400 text-sm">
               <li className="flex gap-3">
                 <span className="text-blue-500">•</span>
-                The game is played in turns.
+                {t("rules.drawing.item1")}
               </li>
               <li className="flex gap-3">
                 <span className="text-blue-500">•</span>
-                In each turn, each player draws a part of the word.
+                {t("rules.drawing.item2")}
               </li>
               <li className="flex gap-3">
                 <span className="text-blue-500">•</span>
-                The drawing is shared: everyone contributes to the same canvas.
+                {t("rules.drawing.item3")}
               </li>
             </ul>
           </section>
@@ -150,17 +152,17 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-purple-500">
               <Search className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                Observe & Deduce
+                {t("rules.deduce.title")}
               </h3>
             </div>
             <ul className="space-y-2 text-stone-400 text-sm">
               <li className="flex gap-3">
                 <span className="text-purple-500">•</span>
-                While drawing, try to figure out who doesn't know the word.
+                {t("rules.deduce.item1")}
               </li>
               <li className="flex gap-3">
                 <span className="text-purple-500">•</span>
-                The impostor must draw carefully to avoid suspicion.
+                {t("rules.deduce.item2")}
               </li>
             </ul>
           </section>
@@ -170,20 +172,20 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-orange-500">
               <Vote className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                Voting Phase
+                {t("rules.voting.title")}
               </h3>
             </div>
             <p className="text-stone-300 text-sm mb-2">
-              At the end of the round:
+              {t("rules.voting.description")}
             </p>
             <ul className="space-y-2 text-stone-400 text-sm">
               <li className="flex gap-3">
                 <span className="text-orange-500">•</span>
-                Players can vote to eliminate someone or skip the vote.
+                {t("rules.voting.item1")}
               </li>
               <li className="flex gap-3">
                 <span className="text-orange-500">•</span>
-                If a player gets the majority of votes, they are eliminated.
+                {t("rules.voting.item2")}
               </li>
             </ul>
           </section>
@@ -193,17 +195,17 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             <div className="flex items-center gap-2 text-green-500">
               <Trophy className="w-5 h-5" />
               <h3 className="font-bold uppercase tracking-wider text-sm">
-                End of the Game
+                {t("rules.end.title")}
               </h3>
             </div>
             <ul className="space-y-2 text-stone-400 text-sm">
               <li className="flex gap-3">
                 <span className="text-green-500">•</span>
-                If the impostor is caught → the players win.
+                {t("rules.end.item1")}
               </li>
               <li className="flex gap-3">
                 <span className="text-green-500">•</span>
-                If the impostor survives → the impostor wins.
+                {t("rules.end.item2")}
               </li>
             </ul>
           </section>
@@ -214,10 +216,11 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
               <Lightbulb className="w-5 h-5 text-yellow-500" />
             </div>
             <div>
-              <h4 className="font-bold text-white text-sm mb-1">Tip</h4>
+              <h4 className="font-bold text-white text-sm mb-1">
+                {t("rules.tip.title")}
+              </h4>
               <p className="text-stone-400 text-sm italic">
-                Draw enough to show you know the word… but don't make it too
-                obvious
+                {t("rules.tip.description")}
               </p>
             </div>
           </div>
@@ -229,7 +232,7 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             onClick={onClose}
             className="w-full py-3 bg-stone-800 hover:bg-stone-700 text-white font-bold rounded-xl transition-all active:scale-[0.98] cursor-pointer"
           >
-            GOT IT!
+            {t("rules.gotIt")}
           </button>
         </div>
       </div>

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -247,6 +247,46 @@
       "makeSure": "Assegura't que tothom conegui el seu rol abans de continuar.",
       "startDrawing": "Començar a Dibuixar",
       "waitingHost": "Esperant l'amfitrió..."
+    },
+    "rules": {
+      "title": "Com Jugar a Inkpostor",
+      "objective": {
+        "title": "Objectiu",
+        "description": "Descobreix qui és l'impostor... o enganya a tothom si ho ets tu."
+      },
+      "setup": {
+        "title": "Configuració",
+        "item1": "Cada jugador rep una paraula secreta.",
+        "item2": "Tots els jugadors reben la mateixa paraula, excepte l'impostor.",
+        "item3": "L'impostor només rep una pista relacionada, no la paraula exacta."
+      },
+      "drawing": {
+        "title": "Turns de Dibuix",
+        "item1": "El joc es desenvolupa per turns.",
+        "item2": "En cada turn, cada jugador dibuixa una part de la paraula.",
+        "item3": "El dibuix és compartit: tothom contribueix al mateix llenç."
+      },
+      "deduce": {
+        "title": "Observar i Deduir",
+        "item1": "Mentre dibuixes, intenta descobrir qui no coneix la paraula.",
+        "item2": "L'impostor ha de dibuixar amb cura per no aixecar sospites."
+      },
+      "voting": {
+        "title": "Fase de Votació",
+        "description": "Al final de la ronda:",
+        "item1": "Els jugadors poden votar per eliminar algú o saltar el vot.",
+        "item2": "Si un jugador rep la majoria dels vots, és eliminat."
+      },
+      "end": {
+        "title": "Fi del Joc",
+        "item1": "Si agafen l'impostor → guanyen els jugadors.",
+        "item2": "Si l'impostor sobreviu → guanya l'impostor."
+      },
+      "tip": {
+        "title": "Consell",
+        "description": "Dibuixa prou per demostrar que coneixes la paraula... però no ho facis massa obvi"
+      },
+      "gotIt": "ENTESOS!"
     }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -247,6 +247,46 @@
       "makeSure": "Make sure everyone knows their role before continuing.",
       "startDrawing": "Start Drawing",
       "waitingHost": "Waiting for Host to begin..."
+    },
+    "rules": {
+      "title": "How to Play Inkpostor",
+      "objective": {
+        "title": "Objective",
+        "description": "Find out who the impostor is… or fool everyone if it's you."
+      },
+      "setup": {
+        "title": "Setup",
+        "item1": "Each player receives a secret word.",
+        "item2": "All players get the same word, except the impostor.",
+        "item3": "The impostor receives only a related hint, not the exact word."
+      },
+      "drawing": {
+        "title": "Drawing Turns",
+        "item1": "The game is played in turns.",
+        "item2": "In each turn, each player draws a part of the word.",
+        "item3": "The drawing is shared: everyone contributes to the same canvas."
+      },
+      "deduce": {
+        "title": "Observe & Deduce",
+        "item1": "While drawing, try to figure out who doesn't know the word.",
+        "item2": "The impostor must draw carefully to avoid suspicion."
+      },
+      "voting": {
+        "title": "Voting Phase",
+        "description": "At the end of the round:",
+        "item1": "Players can vote to eliminate someone or skip the vote.",
+        "item2": "If a player gets the majority of votes, they are eliminated."
+      },
+      "end": {
+        "title": "End of the Game",
+        "item1": "If the impostor is caught → the players win.",
+        "item2": "If the impostor survives → the impostor wins."
+      },
+      "tip": {
+        "title": "Tip",
+        "description": "Draw enough to show you know the word… but don't make it too obvious"
+      },
+      "gotIt": "GOT IT!"
     }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -247,6 +247,46 @@
       "makeSure": "Asegúrate de que todos conozcan su rol antes de continuar.",
       "startDrawing": "Empezar a Dibujar",
       "waitingHost": "Esperando al anfitrión..."
+    },
+    "rules": {
+      "title": "Cómo Jugar a Inkpostor",
+      "objective": {
+        "title": "Objetivo",
+        "description": "Descubre quién es el impostor... o engaña a todos si eres tú."
+      },
+      "setup": {
+        "title": "Configuración",
+        "item1": "Cada jugador recibe una palabra secreta.",
+        "item2": "Todos los jugadores reciben la misma palabra, excepto el impostor.",
+        "item3": "El impostor solo recibe una pista relacionada, no la palabra exacta."
+      },
+      "drawing": {
+        "title": "Turnos de Dibujo",
+        "item1": "El juego se desarrolla por turnos.",
+        "item2": "En cada turno, cada jugador dibuja una parte de la palabra.",
+        "item3": "El dibujo es compartido: todos contribuyen al mismo lienzo."
+      },
+      "deduce": {
+        "title": "Observar y Deducir",
+        "item1": "Mientras dibujas, intenta descubrir quién no conoce la palabra.",
+        "item2": "El impostor debe dibujar con cuidado para no levantar sospechas."
+      },
+      "voting": {
+        "title": "Fase de Votación",
+        "description": "Al final de la ronda:",
+        "item1": "Los jugadores pueden votar para eliminar a alguien o saltar el voto.",
+        "item2": "Si un jugador recibe la mayoría de los votos, es eliminado."
+      },
+      "end": {
+        "title": "Fin del Juego",
+        "item1": "Si pillan al impostor → ganan los jugadores.",
+        "item2": "Si el impostor sobrevive → gana el impostor."
+      },
+      "tip": {
+        "title": "Consejo",
+        "description": "Dibuja lo suficiente para demostrar que conoces la palabra... pero no lo hagas demasiado obvio"
+      },
+      "gotIt": "¡ENTENDIDO!"
     }
   }
 }

--- a/tests/components/RulesTranslations.test.tsx
+++ b/tests/components/RulesTranslations.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Lobby } from "../../src/components/Lobby";
+import { useGameStore } from "../../src/store/gameState";
+import i18n from "../../src/i18n";
+
+// Mock the store
+vi.mock("../../src/store/gameState", () => ({
+  useGameStore: vi.fn(),
+}));
+
+describe("RulesModal Translations", () => {
+  const mockStartGame = vi.fn();
+
+  const mockStateBase = {
+    roomId: "TESTX9",
+    myId: "socket-123",
+    hostId: "socket-123",
+    players: [],
+    actions: { startGame: mockStartGame },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    i18n.changeLanguage("en");
+  });
+
+  const openRules = async () => {
+    (useGameStore as any).mockImplementation((selector: any) => selector(mockStateBase));
+    render(<Lobby />);
+    const howToPlayBtn = screen.getByTestId("how-to-play-btn");
+    await userEvent.click(howToPlayBtn);
+  };
+
+  it("renders rules in English", async () => {
+    await i18n.changeLanguage("en");
+    await openRules();
+
+    expect(screen.getByText("How to Play Inkpostor")).toBeInTheDocument();
+    expect(screen.getByText("Objective")).toBeInTheDocument();
+    expect(screen.getByText("Find out who the impostor is… or fool everyone if it's you.")).toBeInTheDocument();
+    expect(screen.getByText("GOT IT!")).toBeInTheDocument();
+  });
+
+  it("renders rules in Spanish", async () => {
+    await i18n.changeLanguage("es");
+    await openRules();
+
+    expect(screen.getByText("Cómo Jugar a Inkpostor")).toBeInTheDocument();
+    expect(screen.getByText("Objetivo")).toBeInTheDocument();
+    expect(screen.getByText("Descubre quién es el impostor... o engaña a todos si eres tú.")).toBeInTheDocument();
+    expect(screen.getByText("¡ENTENDIDO!")).toBeInTheDocument();
+  });
+
+  it("renders rules in Catalan", async () => {
+    await i18n.changeLanguage("ca");
+    await openRules();
+
+    expect(screen.getByText("Com Jugar a Inkpostor")).toBeInTheDocument();
+    expect(screen.getByText("Objectiu")).toBeInTheDocument();
+    expect(screen.getByText("Descobreix qui és l'impostor... o enganya a tothom si ho ets tu.")).toBeInTheDocument();
+    expect(screen.getByText("ENTESOS!")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
The "How to Play" (RulesModal) section was previously hardcoded in English. This change externalizes all text into the translation JSON files and updates the component to use `react-i18next`. Additionally, the rules are now accessible directly from the initial join screen.

Fixes #63

---
*PR created automatically by Jules for task [5734797493311756585](https://jules.google.com/task/5734797493311756585) started by @jorbush*