### PR TITLE
fix: remove lobby share description

### DIFF
--- a/src/components/Lobby.tsx
+++ b/src/components/Lobby.tsx
@@ -89,8 +89,6 @@ export const Lobby: React.FC = () => {
               <CopyLinkButton roomId={roomId} />
             </div>
           )}
-
-          <p className="text-stone-500 text-sm">{t("lobby.shareCode")}</p>
         </div>
 
         <div className="bg-stone-800 rounded-3xl p-6 shadow-xl border border-stone-700 flex flex-col max-h-[70vh]">

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -17,7 +17,6 @@
       "copyLink": "Copiar enllaç",
       "waitingCode": "Esperant el codi...",
       "copied": "Copiat!",
-      "shareCode": "Comparteix aquest codi amb els teus amics!",
       "players": "Jugadors",
       "joined": "{{count}} / {{max}} units",
       "fullLobby": "Sala plena",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -17,7 +17,6 @@
       "copyLink": "Copy link",
       "waitingCode": "Waiting for room code...",
       "copied": "Copied!",
-      "shareCode": "Share this code with your friends to let them join!",
       "players": "Players",
       "joined": "{{count}} / {{max}} joined",
       "fullLobby": "Full lobby",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -17,7 +17,6 @@
       "copyLink": "Copiar enlace",
       "waitingCode": "Esperando código...",
       "copied": "¡Copiado!",
-      "shareCode": "¡Comparte este código con tus amigos!",
       "players": "Jugadores",
       "joined": "{{count}} / {{max}} unidos",
       "fullLobby": "Sala llena",


### PR DESCRIPTION
Fixes #131

## Summary
- remove the extra share-code description text from the Lobby screen
- remove the now-unused `lobby.shareCode` translation key from English, Spanish, and Catalan locales

## Testing
- `npm test -- tests/components/Lobby.test.tsx`
- `npm run build`

Note: `npm run lint` still reports existing unrelated lint errors across other files, including pre-existing `no-explicit-any` test warnings and a Canvas effect warning.